### PR TITLE
Cache PackageInfo to avoid costly marshalling

### DIFF
--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/AssemblyNameProvider.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/AssemblyNameProvider.cs
@@ -21,8 +21,14 @@ namespace VSCodeEditor
         void ToggleProjectGeneration(ProjectGenerationFlag preference);
     }
 
-    internal class AssemblyNameProvider : IAssemblyNameProvider
+    internal interface IPackageInfoCache{
+        void ResetPackageInfoCache();
+    }
+
+    internal class AssemblyNameProvider : IAssemblyNameProvider, IPackageInfoCache
     {
+        private readonly Dictionary<string, UnityEditor.PackageManager.PackageInfo> m_PackageInfoCache = new Dictionary<string, UnityEditor.PackageManager.PackageInfo>();
+
         ProjectGenerationFlag m_ProjectGenerationFlag = (ProjectGenerationFlag)EditorPrefs.GetInt("unity_project_generation_flag", 0);
 
         public string[] ProjectSupportedExtensions => EditorSettings.projectGenerationUserExtensions;
@@ -53,9 +59,44 @@ namespace VSCodeEditor
             return AssetDatabase.GetAllAssetPaths();
         }
 
+        private static string ResolvePotentialParentPackageAssetPath(string assetPath)
+		{
+			var lowered = assetPath.ToLowerInvariant();
+            if (!lowered.StartsWith("packages/"))
+            {
+				return null;
+			}
+
+			var followupSeparator = lowered.IndexOf('/', "packages/".Length);
+			if (followupSeparator == -1)
+			{
+				return lowered;
+			}
+
+			return lowered.Substring(0, followupSeparator);
+		}
+
+        public void ResetPackageInfoCache()
+		{
+			m_PackageInfoCache.Clear();
+		}
+
         public UnityEditor.PackageManager.PackageInfo FindForAssetPath(string assetPath)
         {
-            return UnityEditor.PackageManager.PackageInfo.FindForAssetPath(assetPath);
+            var parentPackageAssetPath = ResolvePotentialParentPackageAssetPath(assetPath);
+			if (parentPackageAssetPath == null)
+			{
+				return null;
+			}
+
+			if (m_PackageInfoCache.TryGetValue(parentPackageAssetPath, out var cachedPackageInfo))
+			{
+				return cachedPackageInfo;
+			}
+
+			var result = UnityEditor.PackageManager.PackageInfo.FindForAssetPath(parentPackageAssetPath);
+			m_PackageInfoCache[parentPackageAssetPath] = result;
+			return result;
         }
 
         public ResponseFileData ParseResponseFile(string responseFilePath, string projectDirectory, string[] systemReferenceDirectories)

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/AssemblyNameProvider.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/AssemblyNameProvider.cs
@@ -61,19 +61,19 @@ namespace VSCodeEditor
 
         private static string ResolvePotentialParentPackageAssetPath(string assetPath)
 		{
-			var lowered = assetPath.ToLowerInvariant();
-            if (!lowered.StartsWith("packages/"))
+            const string packagesPrefix = "packages/";
+            if (!assetPath.StartsWith(packagesPrefix, StringComparison.OrdinalIgnoreCase))
             {
-				return null;
-			}
+                return null;
+            }
 
-			var followupSeparator = lowered.IndexOf('/', "packages/".Length);
-			if (followupSeparator == -1)
-			{
-				return lowered;
-			}
+            var followupSeparator = assetPath.IndexOf('/', packagesPrefix.Length);
+            if (followupSeparator == -1)
+            {
+                return assetPath.ToLowerInvariant();
+            }
 
-			return lowered.Substring(0, followupSeparator);
+            return assetPath.Substring(0, followupSeparator).ToLowerInvariant();
 		}
 
         public void ResetPackageInfoCache()

--- a/Packages/com.unity.ide.vscode/Editor/VSCodeScriptEditor.cs
+++ b/Packages/com.unity.ide.vscode/Editor/VSCodeScriptEditor.cs
@@ -159,11 +159,13 @@ namespace VSCodeEditor
 
         public void SyncIfNeeded(string[] addedFiles, string[] deletedFiles, string[] movedFiles, string[] movedFromFiles, string[] importedFiles)
         {
+            (m_ProjectGeneration.AssemblyNameProvider as IPackageInfoCache)?.ResetPackageInfoCache();
             m_ProjectGeneration.SyncIfNeeded(addedFiles.Union(deletedFiles).Union(movedFiles).Union(movedFromFiles).ToList(), importedFiles);
         }
 
         public void SyncAll()
         {
+            (m_ProjectGeneration.AssemblyNameProvider as IPackageInfoCache)?.ResetPackageInfoCache();
             AssetDatabase.Refresh();
             m_ProjectGeneration.Sync();
         }


### PR DESCRIPTION
Previous implementation of project generation involved calling
UnityEditor.PackageManager.PackageInfo.FindForAssetPath in a hot
path (once or twice for each asset in the asset DB).

This is not efficient because:

Internal native implementation involves traversing the whole package list
and do a case insensitive comparison
Marshalling of the UpmPackageInfo to its managed counterpart is costly
and it is currently done once per file within each package.
This changeset introduces a better lookup logic and maintain an index of
PackageInfo that avoids both the costly lookups and the repetitive marshalling.

Signed-off-by: Simon Ferquel <simon.ferquel@unity3d.com>