### PR TITLE
Fix paths for source files during project generation

### DIFF
--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -521,7 +521,7 @@ namespace VSCodeEditor
                 .Select(path => MakeAbsolutePath(path, ProjectDirectory).NormalizePath())
                 .ToArray());
         }
-        
+
         private static string MakeAbsolutePath(string path, string projectDirectory)
         {
             return Path.IsPathRooted(path) ? path : Path.Combine(projectDirectory, path);
@@ -685,7 +685,7 @@ namespace VSCodeEditor
             file = file.NormalizePath();
             var path = SkipPathPrefix(file, projectDir);
 
-            var packageInfo = m_AssemblyNameProvider.FindForAssetPath(path.NormalizePath());
+            var packageInfo = m_AssemblyNameProvider.FindForAssetPath(path.Replace('\\', '/'));
             if (packageInfo != null)
             {
                 // We have to normalize the path, because the PackageManagerRemapper assumes


### PR DESCRIPTION
Fixes #4 and #5 using the [visualstudio package](https://github.com/needle-mirror/com.unity.ide.visualstudio/blob/f6444c620ded602e407b6093d08ad8c582043c18/Editor/ProjectGeneration/ProjectGeneration.cs#L927) as a reference.
