### PR TITLE
ProjectGeneration: Fixes file path to analyzers installed from UPM.

### DIFF
--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -566,7 +566,9 @@ namespace VSCodeEditor
                 assembly.name,
                 string.Join(";", new[] { "DEBUG", "TRACE" }.Concat(assembly.defines).Concat(responseFilesData.SelectMany(x => x.Defines)).Concat(EditorUserBuildSettings.activeScriptCompilationDefines).Distinct().ToArray()),
                 assembly.compilerOptions.AllowUnsafeCode | responseFilesData.Any(x => x.Unsafe),
-                CreateAnalyzerBlock(otherArguments, assembly));
+                CreateAnalyzerBlock(otherArguments, assembly),
+                assembly.compilerOptions.RoslynAnalyzerRulesetPath
+            );
         }
 
         string CreateAnalyzerBlock(ILookup<string, string> otherArguments, Assembly assembly)
@@ -648,7 +650,8 @@ namespace VSCodeEditor
             string assemblyName,
             string defines,
             bool allowUnsafe,
-            string analyzerBlock
+            string analyzerBlock,
+            string rulesetFilePath
         )
         {
             builder.Append(@"<?xml version=""1.0"" encoding=""utf-8""?>").Append(k_WindowsNewline);
@@ -687,6 +690,10 @@ namespace VSCodeEditor
             builder.Append(@"    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>").Append(k_WindowsNewline);
             builder.Append(@"    <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>").Append(k_WindowsNewline);
             builder.Append(@"    <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>").Append(k_WindowsNewline);
+#if UNITY_2020_2_OR_NEWER
+            if (rulesetFilePath != null)
+              builder.Append(@$"    <CodeAnalysisRuleSet>{rulesetFilePath}</CodeAnalysisRuleSet>");
+#endif
             builder.Append(@"  </PropertyGroup>").Append(k_WindowsNewline);
             builder.Append(analyzerBlock);
             builder.Append(@"  <ItemGroup>").Append(k_WindowsNewline);

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -692,7 +692,7 @@ namespace VSCodeEditor
             builder.Append(@"    <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>").Append(k_WindowsNewline);
 #if UNITY_2020_2_OR_NEWER
             if (rulesetFilePath != null)
-              builder.Append(@$"    <CodeAnalysisRuleSet>{rulesetFilePath}</CodeAnalysisRuleSet>");
+              builder.Append(@$"    <CodeAnalysisRuleSet>{rulesetFilePath}</CodeAnalysisRuleSet>").Append(k_WindowsNewline);
 #endif
             builder.Append(@"  </PropertyGroup>").Append(k_WindowsNewline);
             builder.Append(analyzerBlock);

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -118,6 +118,9 @@ namespace VSCodeEditor
         static readonly string[] k_ReimportSyncExtensions = { ".dll", ".asmdef" };
 
         string[] m_ProjectSupportedExtensions = new string[0];
+
+        string InitialWorkingDirectory;
+
         public string ProjectDirectory { get; }
         IAssemblyNameProvider IGenerator.AssemblyNameProvider => m_AssemblyNameProvider;
 
@@ -258,10 +261,14 @@ namespace VSCodeEditor
 
         public void Sync()
         {
+            InitialWorkingDirectory = Environment.CurrentDirectory;
+            Environment.CurrentDirectory = ProjectDirectory;
+
             SetupProjectSupportedExtensions();
             GenerateAndWriteSolutionAndProjects();
 
             OnGeneratedCSProjectFiles();
+            Environment.CurrentDirectory = InitialWorkingDirectory;
         }
 
         public bool SolutionExists()
@@ -572,7 +579,7 @@ namespace VSCodeEditor
                 .Concat(m_AssemblyNameProvider.GetRoslynAnalyzerPaths())
 #endif
                 .Distinct()
-                .Select(path => MakeAbsolutePath(path, ProjectDirectory).NormalizePath())
+                .Select(path => Path.GetFullPath(path))
                 .ToArray());
         }
         


### PR DESCRIPTION
Path.GetFullPath substitutes "Packages" part of the path to "Library/PackageCache" when it is needed
so that RoslynAnalyzers installed from UPM works for IDE as well as for Unity itself.