### PR TITLE
Add extra snap search path

### DIFF
--- a/Packages/com.unity.ide.vscode/Editor/VSCodeDiscovery.cs
+++ b/Packages/com.unity.ide.vscode/Editor/VSCodeDiscovery.cs
@@ -51,7 +51,8 @@ namespace VSCodeEditor
                 "/bin/code",
                 "/usr/local/bin/code",
                 "/var/lib/flatpak/exports/bin/com.visualstudio.code",
-                "/snap/current/bin/code"
+                "/snap/current/bin/code",
+                "/snap/bin/code"
             };
 #endif
             var existingPaths = possiblePaths.Where(VSCodeExists).ToList();


### PR DESCRIPTION
On Ubuntu Software for 20.04, installing code puts it in `/snap/bin/`.
Without this extra path, unity fails to show VSCode as External Script Editor