### PR TITLE
Specify correct C# language version in generated project files.

### DIFF
--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
@@ -60,6 +60,14 @@ namespace VSCodeEditor.Tests
             [Test]
             public void DefaultSyncSettings_WhenSynced_CreatesProjectFileFromDefaultTemplate()
             {
+#if UNITY_2021_2_OR_NEWER
+                const string versionCSharp = "9.0";
+#elif UNITY_2020_2_OR_NEWER
+                const string versionCSharp = "8.0";
+#else
+                const string versionCSharp = "7.3";
+#endif
+
                 var projectGuid = "ProjectGuid";
                 var synchronizer = m_Builder.WithProjectGuid(projectGuid, m_Builder.Assembly).Build();
 
@@ -72,7 +80,7 @@ namespace VSCodeEditor.Tests
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
                     "<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">",
                     "  <PropertyGroup>",
-                    "    <LangVersion>latest</LangVersion>",
+                    $"    <LangVersion>{versionCSharp}</LangVersion>",
                     "  </PropertyGroup>",
                     "  <PropertyGroup>",
                     "    <Configuration Condition=\" '$(Configuration)' == '' \">Debug</Configuration>",
@@ -510,7 +518,13 @@ namespace VSCodeEditor.Tests
             [Test]
             public void CheckDefaultLangVersion()
             {
-                CheckOtherArgument(new string[0], "<LangVersion>latest</LangVersion>");
+#if UNITY_2021_2_OR_NEWER        
+                CheckOtherArgument(new string[0], "<LangVersion>9.0</LangVersion>");
+#elif UNITY_2020_2_OR_NEWER        
+                CheckOtherArgument(new string[0], "<LangVersion>8.0</LangVersion>");
+#else
+                CheckOtherArgument(new string[0], "<LangVersion>7.3</LangVersion>");
+#endif
             }
 
             public void CheckOtherArgument(string[] argumentString, params string[] expectedContents)
@@ -579,7 +593,7 @@ namespace VSCodeEditor.Tests
                 XmlDocument scriptProject = XMLUtilities.FromText(csprojFileContents);
                 XMLUtilities.AssertCompileItemsMatchExactly(scriptProject, new[] { "file.cs" });
                 XMLUtilities.AssertNonCompileItemsMatchExactly(scriptProject, new string[0]);
-                Assert.That(csprojFileContents, Does.Match($"<Reference Include=\"reference\">\\W*<HintPath>{Regex.Escape(Path.Combine(SynchronizerBuilder.projectDirectory,referenceDll))}\\W*</HintPath>\\W*</Reference>"));
+                Assert.That(csprojFileContents, Does.Match($"<Reference Include=\"reference\">\\W*<HintPath>{Regex.Escape(Path.Combine(SynchronizerBuilder.projectDirectory, referenceDll))}\\W*</HintPath>\\W*</Reference>"));
             }
 
             [Test]

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -144,8 +144,13 @@ namespace VSCodeEditor
         const string k_ProductVersion = "10.0.20506";
         const string k_BaseDirectory = ".";
         const string k_TargetFrameworkVersion = "v4.7.1";
-        const string k_TargetLanguageVersion = "latest";
-
+#if UNITY_2021_2_OR_NEWER        
+        const string k_TargetLanguageVersion = "9.0";
+#elif UNITY_2020_2_OR_NEWER        
+        const string k_TargetLanguageVersion = "8.0";
+#else
+        const string k_TargetLanguageVersion = "7.3";
+#endif
         public ProjectGeneration(string tempDirectory)
             : this(tempDirectory, new AssemblyNameProvider(), new FileIOProvider(), new GUIDProvider()) { }
 


### PR DESCRIPTION
This pull request improves the way the C# language version is set in the generated project files. Instead of setting the language version to "latest", which in most cases is inaccurate, it sets the C# language version to the specific version that matches the current Unity version. This solves several issues with code analysis, refactoring and intellisense and fixes #12.