### PR TITLE
No longer hide .gitignore from VS Code's project explorer

### DIFF
--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -41,7 +41,6 @@ namespace VSCodeEditor
     {
         ""**/.DS_Store"":true,
         ""**/.git"":true,
-        ""**/.gitignore"":true,
         ""**/.gitmodules"":true,
         ""**/*.booproj"":true,
         ""**/*.pidb"":true,


### PR DESCRIPTION
**Summary**

This PR changes the project generation code so the local configuration for VS Code no longer hides the `.gitignore` file from the user.

**Explanation**

This package creates a local configuration for Visual Studio code that configures the editor to hide a number of files from the editor. These files are mostly binaries, exported builds etc. -- so, files you probably wouldn't want to open in the editor, anyway. But it unfortunately also hides `.gitignore`. This is an important file when working with Git that you absolutely _do_ want to have access to (and edit).

With the generated configuration what it currently is, the only way to explicitly open this file is to specifically navigate to it outside of the editor.

The problem is exacerbated by the fact that the editor configuration is re-written by this package when regenerating project files.

**Tests**

I didn't find any tests that specifically test for this, so no tests were changed.