### PR TITLE
chore: Fix LangVersion tests

### DIFF
--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
@@ -517,7 +517,13 @@ namespace VSCodeEditor.Tests
             [Test]
             public void CheckDefaultLangVersion()
             {
-                CheckOtherArgument(new string[0], "<LangVersion>latest</LangVersion>");
+#if UNITY_2021_2_OR_NEWER        
+                CheckOtherArgument(new string[0], "<LangVersion>9.0</LangVersion>");
+#elif UNITY_2020_2_OR_NEWER        
+                CheckOtherArgument(new string[0], "<LangVersion>8.0</LangVersion>");
+#else
+                CheckOtherArgument(new string[0], "<LangVersion>7.3</LangVersion>");
+#endif
             }
 
             public void CheckOtherArgument(string[] argumentString, params string[] expectedContents)


### PR DESCRIPTION
This PR fixes the test suite for the different the language versions introduced by #16. Sorry for this extra PR.

@Rares95 or @hknielsen, could you take a look? If the tests pass, it may be ready for publishing a new version of the package.