### PR TITLE
1.2.5

### DIFF
--- a/.yamato/CI.yml
+++ b/.yamato/CI.yml
@@ -209,5 +209,5 @@ create_pull_request:
     flavor: b1.large
   commands:
     - git clone git@github.cds.internal.unity3d.com:nicklas/Nicklas-CI.git /tmp/Nicklas-CI
-    - python3 /tmp/Nicklas-CI/create_pullrequest.py nicklas upm-ci~/packages/packages.json
-    - python3 /tmp/Nicklas-CI/start_katana.py "Nicklas Pingel <nicklas@unity3d.com>" upm-ci~/packages/packages.json
+    - python3 /tmp/Nicklas-CI/create_pullrequest.py simon.ferquel upm-ci~/packages/packages.json
+    - python3 /tmp/Nicklas-CI/start_katana.py "Simon Ferquel <simon.ferquel@unity3d.com>" upm-ci~/packages/packages.json

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
@@ -60,6 +60,14 @@ namespace VSCodeEditor.Tests
             [Test]
             public void DefaultSyncSettings_WhenSynced_CreatesProjectFileFromDefaultTemplate()
             {
+#if UNITY_2021_2_OR_NEWER
+                const string versionCSharp = "9.0";
+#elif UNITY_2020_2_OR_NEWER
+                const string versionCSharp = "8.0";
+#else
+                const string versionCSharp = "7.3";
+#endif
+
                 var projectGuid = "ProjectGuid";
                 var synchronizer = m_Builder.WithProjectGuid(projectGuid, m_Builder.Assembly).Build();
 
@@ -72,7 +80,7 @@ namespace VSCodeEditor.Tests
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
                     "<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">",
                     "  <PropertyGroup>",
-                    "    <LangVersion>latest</LangVersion>",
+                    $"    <LangVersion>{versionCSharp}</LangVersion>",
                     "  </PropertyGroup>",
                     "  <PropertyGroup>",
                     "    <Configuration Condition=\" '$(Configuration)' == '' \">Debug</Configuration>",
@@ -510,7 +518,13 @@ namespace VSCodeEditor.Tests
             [Test]
             public void CheckDefaultLangVersion()
             {
-                CheckOtherArgument(new string[0], "<LangVersion>latest</LangVersion>");
+#if UNITY_2021_2_OR_NEWER        
+                CheckOtherArgument(new string[0], "<LangVersion>9.0</LangVersion>");
+#elif UNITY_2020_2_OR_NEWER        
+                CheckOtherArgument(new string[0], "<LangVersion>8.0</LangVersion>");
+#else
+                CheckOtherArgument(new string[0], "<LangVersion>7.3</LangVersion>");
+#endif
             }
 
             public void CheckOtherArgument(string[] argumentString, params string[] expectedContents)
@@ -579,7 +593,7 @@ namespace VSCodeEditor.Tests
                 XmlDocument scriptProject = XMLUtilities.FromText(csprojFileContents);
                 XMLUtilities.AssertCompileItemsMatchExactly(scriptProject, new[] { "file.cs" });
                 XMLUtilities.AssertNonCompileItemsMatchExactly(scriptProject, new string[0]);
-                Assert.That(csprojFileContents, Does.Match($"<Reference Include=\"reference\">\\W*<HintPath>{Regex.Escape(Path.Combine(SynchronizerBuilder.projectDirectory,referenceDll))}\\W*</HintPath>\\W*</Reference>"));
+                Assert.That(csprojFileContents, Does.Match($"<Reference Include=\"reference\">\\W*<HintPath>{Regex.Escape(Path.Combine(SynchronizerBuilder.projectDirectory, referenceDll))}\\W*</HintPath>\\W*</Reference>"));
             }
 
             [Test]

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/CSProjectTests.cs
@@ -763,10 +763,14 @@ namespace VSCodeEditor.Tests
         {
             static bool m_HasCalledOnGeneratedCSProject = false;
 
+            static bool m_isRunningThisTest = false;
+
             public class OnGenerationCallbacks : AssetPostprocessor 
             {
                 public static string OnGeneratedCSProject(string path, string content) 
                 {
+                    if(!m_isRunningThisTest) return content;
+
                     m_HasCalledOnGeneratedCSProject = true;
                     return content.Replace("fileA", "fileD");
                 }
@@ -775,15 +779,21 @@ namespace VSCodeEditor.Tests
             [Test]
             public void OnGenerationProject_Called()
             {
+                m_isRunningThisTest = true;
+                
                 var synchronizer = m_Builder.Build();
                 synchronizer.Sync();
 
                 Assert.True(m_HasCalledOnGeneratedCSProject);
+
+                m_isRunningThisTest = false;
             }
 
             [Test]
             public void OnGenerationProject_Modifed()
             {
+                m_isRunningThisTest = true;
+
                 var files = new[] { "fileA.cs", "fileB.cs", "fileC.cs" };
                 var synchronizer = m_Builder
                     .WithAssemblyData(files: files)
@@ -795,6 +805,9 @@ namespace VSCodeEditor.Tests
                 StringAssert.DoesNotContain("fileA.cs", csprojFileContents);
                 StringAssert.Contains("fileD.cs", csprojFileContents);
                 Assert.True(m_HasCalledOnGeneratedCSProject);
+
+                m_isRunningThisTest = false;
+
             }
         }
     }

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/Helper.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/Helper.cs
@@ -1,0 +1,18 @@
+using UnityEditor.Compilation;
+
+namespace VSCodeEditor.Tests
+{
+    public static class Helper
+    {
+        public static string GetLangVersion()
+        {
+            var languageVersion =
+#if UNITY_2020_2_OR_NEWER
+                new ScriptCompilerOptions().LanguageVersion;
+#else
+                "latest";
+#endif
+            return languageVersion;
+        }
+    }
+}

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/Helper.cs.meta
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/Helper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 44504e25e86f4e2eab3f97a61d5c3e37
+timeCreated: 1643815839

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/MockFileIO.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/MockFileIO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using NUnit.Framework;
 
@@ -30,6 +31,13 @@ namespace VSCodeEditor.Tests
             var utf8 = Encoding.UTF8;
             byte[] utfBytes = utf8.GetBytes(content);
             fileToContent[fileName] = utf8.GetString(utfBytes, 0, utfBytes.Length);
+        }
+        
+        public string EscapedRelativePathFor(string file, string projectDirectory)
+        {
+            return file.NormalizePath().StartsWith($"{projectDirectory}{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                ? file.Substring(projectDirectory.Length + 1)
+                : file.NormalizePath();
         }
 
         public void DeleteFile(string fileName)

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/SolutionGenerationTestBase.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/SolutionGenerationTestBase.cs
@@ -27,10 +27,15 @@ namespace VSCodeEditor.Tests
         {
             m_Builder = new SynchronizerBuilder();
         }
-            
-        protected static string MakeAbsolutePath(string path)
+
+        protected static string MakeAbsolutePathTestImplementation(string path)
         {
             return Path.IsPathRooted(path) ? path : Path.Combine(SynchronizerBuilder.projectDirectory, path);
+        }
+        
+        protected static string MakeAbsolutePath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : Path.GetFullPath(path);
         }
     }
 }

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/SolutionTests.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/SolutionTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEditor.Compilation;
+using UnityEditor;
+
 
 namespace VSCodeEditor.Tests
 {
@@ -269,6 +271,47 @@ namespace VSCodeEditor.Tests
                 synchronizer.Sync();
 
                 Assert.AreEqual(solutionTemplate, m_Builder.ReadFile(synchronizer.SolutionFile()));
+            }
+        }
+
+        class OnGenerationSolution : ProjectGenerationTestBase 
+        {
+            static bool m_HasCalledOnGeneratedSlnSolution = false;
+
+            const string solutionGUID = "SolutionGUID";
+            const string newSolutionGUID = "1234567";
+
+            public class OnGenerationCallbacks : AssetPostprocessor 
+            {
+                public static string OnGeneratedSlnSolution(string path, string content)
+                {
+                    m_HasCalledOnGeneratedSlnSolution = true;
+                    return content.Replace(solutionGUID, newSolutionGUID);
+                }
+            }
+
+            [Test]
+            public void OnGenerationSolution_Called()
+            {
+                var synchronizer = m_Builder.Build();
+                synchronizer.Sync();
+
+                Assert.True(m_HasCalledOnGeneratedSlnSolution);
+            }
+
+            [Test]
+            public void OnGenerationSolution_Modifed()
+            {
+                var synchronizer = m_Builder
+                    .WithSolutionGuid(solutionGUID)
+                    .Build();
+
+                synchronizer.Sync();
+
+                var slnFileContents = m_Builder.ReadFile(synchronizer.SolutionFile());
+                StringAssert.DoesNotContain(solutionGUID, slnFileContents);
+                StringAssert.Contains(newSolutionGUID, slnFileContents);
+                Assert.True(m_HasCalledOnGeneratedSlnSolution);
             }
         }
     }

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/SolutionTests.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/SolutionTests.cs
@@ -281,10 +281,16 @@ namespace VSCodeEditor.Tests
             const string solutionGUID = "SolutionGUID";
             const string newSolutionGUID = "1234567";
 
+            // This is here because the fact this OnGenerationCallbacks is around 
+            // will cause it to get executed.
+            static bool m_isRunningThisTest = false;
+
             public class OnGenerationCallbacks : AssetPostprocessor 
             {
                 public static string OnGeneratedSlnSolution(string path, string content)
                 {
+                    if(!m_isRunningThisTest) return content;
+
                     m_HasCalledOnGeneratedSlnSolution = true;
                     return content.Replace(solutionGUID, newSolutionGUID);
                 }
@@ -293,15 +299,21 @@ namespace VSCodeEditor.Tests
             [Test]
             public void OnGenerationSolution_Called()
             {
+                m_isRunningThisTest = true;
+
                 var synchronizer = m_Builder.Build();
                 synchronizer.Sync();
 
                 Assert.True(m_HasCalledOnGeneratedSlnSolution);
+
+                m_isRunningThisTest = false;
             }
 
             [Test]
             public void OnGenerationSolution_Modifed()
             {
+                m_isRunningThisTest = true;
+
                 var synchronizer = m_Builder
                     .WithSolutionGuid(solutionGUID)
                     .Build();
@@ -312,6 +324,8 @@ namespace VSCodeEditor.Tests
                 StringAssert.DoesNotContain(solutionGUID, slnFileContents);
                 StringAssert.Contains(newSolutionGUID, slnFileContents);
                 Assert.True(m_HasCalledOnGeneratedSlnSolution);
+
+                m_isRunningThisTest = false;
             }
         }
     }

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/Unity.com.unity.ide.vscode.EditorTests.asmdef
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/Unity.com.unity.ide.vscode.EditorTests.asmdef
@@ -17,5 +17,21 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2021.2.0a9",
+            "define": "ROSLYN_ANALYZER_FIX"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2021.1.2f1,2021.2.0a1]",
+            "define": "ROSLYN_ANALYZER_FIX"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2020.3.6f1,2021.0]",
+            "define": "ROSLYN_ANALYZER_FIX"
+        }
+    ]
 }

--- a/Packages/com.unity.ide.vscode.tests/Tests/Editor/XMLUtilities.cs
+++ b/Packages/com.unity.ide.vscode.tests/Tests/Editor/XMLUtilities.cs
@@ -19,6 +19,13 @@ namespace VSCodeEditor.Tests
                 expected: RelativeAssetPathsFor(expectedAnalyzers), 
                 actual:projectXml.SelectAttributeValues("/msb:Project/msb:ItemGroup/msb:Analyzer/@Include", GetModifiedXmlNamespaceManager(projectXml)).ToArray());
         }
+        
+        public static void AssertAnalyzerRuleSetsMatchExactly(XmlDocument projectXml, string expectedRuleSetFile)
+        {
+            CollectionAssert.Contains(
+                projectXml.SelectInnerText("/msb:Project/msb:PropertyGroup/msb:CodeAnalysisRuleSet",
+                    GetModifiedXmlNamespaceManager(projectXml)).ToArray(), expectedRuleSetFile);
+        }
 
         public static void AssertNonCompileItemsMatchExactly(XmlDocument projectXml, IEnumerable<string> expectedNoncompileItems)
         {
@@ -43,6 +50,15 @@ namespace VSCodeEditor.Tests
             var result = xmlDocument.SelectNodes(xpathQuery, xmlNamespaceManager);
             foreach (XmlAttribute attribute in result)
                 yield return attribute.Value;
+        }
+
+        static IEnumerable<string> SelectInnerText(this XmlDocument xmlDocument, string xpathQuery, XmlNamespaceManager xmlNamespaceManager)
+        {
+            var result = xmlDocument.SelectNodes(xpathQuery, xmlNamespaceManager);
+            foreach (XmlElement node in result)
+            {
+                yield return node.InnerText;
+            }
         }
 
         public static XmlDocument FromText(string textContent)

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/FileIO.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/FileIO.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Security;
 using System.Text;
 
 namespace VSCodeEditor
@@ -11,6 +13,7 @@ namespace VSCodeEditor
         void WriteAllText(string fileName, string content);
 
         void CreateDirectory(string pathName);
+        string EscapedRelativePathFor(string file, string projectDirectory);
     }
 
     class FileIOProvider : IFileIO
@@ -33,6 +36,25 @@ namespace VSCodeEditor
         public void CreateDirectory(string pathName)
         {
             Directory.CreateDirectory(pathName);
+        }
+
+        public string EscapedRelativePathFor(string file, string projectDirectory)
+        {
+            var projectDir = Path.GetFullPath(projectDirectory);
+
+            // We have to normalize the path, because the PackageManagerRemapper assumes
+            // dir seperators will be os specific.
+            var absolutePath = Path.GetFullPath(file.NormalizePath());
+            var path = SkipPathPrefix(absolutePath, projectDir);
+
+            return SecurityElement.Escape(path);
+        }
+
+        private static string SkipPathPrefix(string path, string prefix)
+        {
+            return path.StartsWith($@"{prefix}{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                ? path.Substring(prefix.Length + 1)
+                : path;
         }
     }
 }

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -575,7 +575,7 @@ namespace VSCodeEditor
                 .Select(path => MakeAbsolutePath(path, ProjectDirectory).NormalizePath())
                 .ToArray());
         }
-        
+
         private static string MakeAbsolutePath(string path, string projectDirectory)
         {
             return Path.IsPathRooted(path) ? path : Path.Combine(projectDirectory, path);
@@ -739,7 +739,7 @@ namespace VSCodeEditor
             file = file.NormalizePath();
             var path = SkipPathPrefix(file, projectDir);
 
-            var packageInfo = m_AssemblyNameProvider.FindForAssetPath(path.NormalizePath());
+            var packageInfo = m_AssemblyNameProvider.FindForAssetPath(path.Replace('\\', '/'));
             if (packageInfo != null)
             {
                 // We have to normalize the path, because the PackageManagerRemapper assumes

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -148,8 +148,13 @@ namespace VSCodeEditor
         const string k_ProductVersion = "10.0.20506";
         const string k_BaseDirectory = ".";
         const string k_TargetFrameworkVersion = "v4.7.1";
-        const string k_TargetLanguageVersion = "latest";
-
+#if UNITY_2021_2_OR_NEWER        
+        const string k_TargetLanguageVersion = "9.0";
+#elif UNITY_2020_2_OR_NEWER        
+        const string k_TargetLanguageVersion = "8.0";
+#else
+        const string k_TargetLanguageVersion = "7.3";
+#endif
         public ProjectGeneration(string tempDirectory)
             : this(tempDirectory, new AssemblyNameProvider(), new FileIOProvider(), new GUIDProvider()) { }
 

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -566,7 +566,9 @@ namespace VSCodeEditor
                 assembly.name,
                 string.Join(";", new[] { "DEBUG", "TRACE" }.Concat(assembly.defines).Concat(responseFilesData.SelectMany(x => x.Defines)).Concat(EditorUserBuildSettings.activeScriptCompilationDefines).Distinct().ToArray()),
                 assembly.compilerOptions.AllowUnsafeCode | responseFilesData.Any(x => x.Unsafe),
-                CreateAnalyzerBlock(otherArguments, assembly));
+                CreateAnalyzerBlock(otherArguments, assembly),
+                assembly.compilerOptions.RoslynAnalyzerRulesetPath
+            );
         }
 
         string CreateAnalyzerBlock(ILookup<string, string> otherArguments, Assembly assembly)
@@ -648,7 +650,8 @@ namespace VSCodeEditor
             string assemblyName,
             string defines,
             bool allowUnsafe,
-            string analyzerBlock
+            string analyzerBlock,
+            string rulesetFilePath
         )
         {
             builder.Append(@"<?xml version=""1.0"" encoding=""utf-8""?>").Append(k_WindowsNewline);
@@ -687,6 +690,10 @@ namespace VSCodeEditor
             builder.Append(@"    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>").Append(k_WindowsNewline);
             builder.Append(@"    <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>").Append(k_WindowsNewline);
             builder.Append(@"    <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>").Append(k_WindowsNewline);
+#if UNITY_2020_2_OR_NEWER
+            if (rulesetFilePath != null)
+              builder.Append(@$"    <CodeAnalysisRuleSet>{rulesetFilePath}</CodeAnalysisRuleSet>");
+#endif
             builder.Append(@"  </PropertyGroup>").Append(k_WindowsNewline);
             builder.Append(analyzerBlock);
             builder.Append(@"  <ItemGroup>").Append(k_WindowsNewline);

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -567,7 +567,7 @@ namespace VSCodeEditor
                 string.Join(";", new[] { "DEBUG", "TRACE" }.Concat(assembly.defines).Concat(responseFilesData.SelectMany(x => x.Defines)).Concat(EditorUserBuildSettings.activeScriptCompilationDefines).Distinct().ToArray()),
                 assembly.compilerOptions.AllowUnsafeCode | responseFilesData.Any(x => x.Unsafe),
                 CreateAnalyzerBlock(otherArguments, assembly),
-                assembly.compilerOptions.RoslynAnalyzerRulesetPath
+                Path.GetRelativePath(ProjectDirectory, assembly.compilerOptions.RoslynAnalyzerRulesetPath)
             );
         }
 
@@ -581,7 +581,7 @@ namespace VSCodeEditor
                 .Concat(m_AssemblyNameProvider.GetRoslynAnalyzerPaths())
 #endif
                 .Distinct()
-                .Select(path => Path.GetFullPath(path))
+                .Select(Path.GetFullPath)
                 .ToArray());
         }
 

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -42,7 +42,6 @@ namespace VSCodeEditor
     {
         ""**/.DS_Store"":true,
         ""**/.git"":true,
-        ""**/.gitignore"":true,
         ""**/.gitmodules"":true,
         ""**/*.booproj"":true,
         ""**/*.pidb"":true,

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -692,7 +692,7 @@ namespace VSCodeEditor
             builder.Append(@"    <ImplicitlyExpandDesignTimeFacades>false</ImplicitlyExpandDesignTimeFacades>").Append(k_WindowsNewline);
 #if UNITY_2020_2_OR_NEWER
             if (rulesetFilePath != null)
-              builder.Append(@$"    <CodeAnalysisRuleSet>{rulesetFilePath}</CodeAnalysisRuleSet>");
+              builder.Append(@$"    <CodeAnalysisRuleSet>{rulesetFilePath}</CodeAnalysisRuleSet>").Append(k_WindowsNewline);
 #endif
             builder.Append(@"  </PropertyGroup>").Append(k_WindowsNewline);
             builder.Append(analyzerBlock);

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/ProjectGeneration.cs
@@ -118,6 +118,9 @@ namespace VSCodeEditor
         static readonly string[] k_ReimportSyncExtensions = { ".dll", ".asmdef" };
 
         string[] m_ProjectSupportedExtensions = new string[0];
+
+        string InitialWorkingDirectory;
+
         public string ProjectDirectory { get; }
         IAssemblyNameProvider IGenerator.AssemblyNameProvider => m_AssemblyNameProvider;
 
@@ -258,10 +261,14 @@ namespace VSCodeEditor
 
         public void Sync()
         {
+            InitialWorkingDirectory = Environment.CurrentDirectory;
+            Environment.CurrentDirectory = ProjectDirectory;
+
             SetupProjectSupportedExtensions();
             GenerateAndWriteSolutionAndProjects();
 
             OnGeneratedCSProjectFiles();
+            Environment.CurrentDirectory = InitialWorkingDirectory;
         }
 
         public bool SolutionExists()
@@ -572,7 +579,7 @@ namespace VSCodeEditor
                 .Concat(m_AssemblyNameProvider.GetRoslynAnalyzerPaths())
 #endif
                 .Distinct()
-                .Select(path => MakeAbsolutePath(path, ProjectDirectory).NormalizePath())
+                .Select(path => Path.GetFullPath(path))
                 .ToArray());
         }
 

--- a/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/StringUtils.cs
+++ b/Packages/com.unity.ide.vscode/Editor/ProjectGeneration/StringUtils.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Unity.VSCode.EditorTests")]
 
-namespace VSCodeEditor.Tests
+namespace VSCodeEditor
 {
     internal static class StringUtils
     {

--- a/Packages/com.unity.ide.vscode/Editor/Unity.com.unity.vscode.Editor.asmdef
+++ b/Packages/com.unity.ide.vscode/Editor/Unity.com.unity.vscode.Editor.asmdef
@@ -5,5 +5,22 @@
     "includePlatforms": [
         "Editor"
     ],
-    "excludePlatforms": []
+    "excludePlatforms": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2021.2.0a9",
+            "define": "ROSLYN_ANALYZER_FIX"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2021.1.2f1,2021.2.0a1]",
+            "define": "ROSLYN_ANALYZER_FIX"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2020.3.6f1,2021.0]",
+            "define": "ROSLYN_ANALYZER_FIX"
+        }
+    ]
 }

--- a/Packages/com.unity.ide.vscode/Editor/VSCodeDiscovery.cs
+++ b/Packages/com.unity.ide.vscode/Editor/VSCodeDiscovery.cs
@@ -51,7 +51,8 @@ namespace VSCodeEditor
                 "/bin/code",
                 "/usr/local/bin/code",
                 "/var/lib/flatpak/exports/bin/com.visualstudio.code",
-                "/snap/current/bin/code"
+                "/snap/current/bin/code",
+                "/snap/bin/code"
             };
 #endif
             var existingPaths = possiblePaths.Where(VSCodeExists).ToList();

--- a/Packages/com.unity.ide.vscode/ValidationExceptions.json
+++ b/Packages/com.unity.ide.vscode/ValidationExceptions.json
@@ -1,0 +1,10 @@
+{
+    "ErrorExceptions": [
+        {
+            "ValidationTest": "API Validation",
+            "ExceptionMessage": "Additions require a new minor or major version.",
+            "PackageVersion": "1.2.3"
+        }
+    ],
+    "WarningExceptions": []
+}

--- a/Packages/com.unity.ide.vscode/ValidationExceptions.json.meta
+++ b/Packages/com.unity.ide.vscode/ValidationExceptions.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc368c32d6432ff4bb374d520000749c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Introduce OnGeneratedCSProjectFiles, OnGeneratedCSProject and OnGeneratedSlnSolution callbacks.
- Always use forward slash in source paths
- Analyzers use absolute paths
- Ruleset files for roslyn analyzers
- Extra snap search paths on Ubuntu
- Specific c# language version for specific unity versions
- No longer hide .gitignore in VSCode file explorer